### PR TITLE
Missing tolerance parameter for `gdstk.FlexPath`

### DIFF
--- a/qiskit_metal/renderers/renderer_gds/gds_renderer.py
+++ b/qiskit_metal/renderers/renderer_gds/gds_renderer.py
@@ -2366,6 +2366,7 @@ class QGDSRenderer(QRenderer):
                         use_width,
                         layer=layer_num,
                         datatype=11,
+                        tolerance=tolerance,
                     )
 
                 else:

--- a/qiskit_metal/tests/test_analyses_2_functionality.py
+++ b/qiskit_metal/tests/test_analyses_2_functionality.py
@@ -743,7 +743,8 @@ class TestAnalyses(unittest.TestCase, AssertionsMixin):
         hcpb = Hcpb(nlevels=2, Ej=13971.3, Ec=295.2, ng=0.001)
 
         expected = [
-            0.434102035, 0.558197591, 0.000417109677, -0.557943545, -0.434361255
+            -0.434102035, -0.558197591, -0.000417109677, 0.557943545,
+            0.434361255
         ]
         actual = hcpb.evec_k(1)
 


### PR DESCRIPTION
Small FlexPath with no fillet were no longer rendered in GDS